### PR TITLE
fixed circular dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(openvdb_catkin)
 
 find_package(catkin_simple REQUIRED)
-catkin_simple()
+catkin_simple(ALL_DEPS_REQUIRED)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -12,16 +12,17 @@ find_package(Log4cplus REQUIRED)
 find_package(ZLIB REQUIRED)
 
 include_directories(include)
-include_directories(${OPENEXR_INCLUDE_DIRS})
+include_directories(${CPPUNIT_INCLUDE_DIRS})
+include_directories(${OPENEXR_INCLUDE_PATHS})
 include_directories(${HALF_INCLUDE_DIRS})
 include_directories(${CPPUNIT_INCLUDE_DIRS})
 include_directories(${PYTHON_INCLUDE_DIRS})
-include_directories(${BOOST_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${TBB_INCLUDE_DIRS})
 include_directories(${LOG4CPLUS_INCLUDES})
 include_directories(${ZLIB_INCLUDE_DIRS})
 
-include_directories(${PROJECT_SOURCE_DIR} )
+include_directories(${PROJECT_SOURCE_DIR})
 
 set(BOOST_LIBRARIES boost_iostreams boost_system)
 

--- a/cmake/openvdb-extras.cmake.in
+++ b/cmake/openvdb-extras.cmake.in
@@ -1,3 +1,3 @@
 # This overrides the dependency tracker with the OpenVDB library file.
-set(OpenVDBLibraries "${CATKIN_DEVEL_PREFIX}/lib/libopenvdb.so")
+set(OpenVDBLibraries "${CATKIN_DEVEL_PREFIX}/lib/libopenvdb${CMAKE_SHARED_LIBRARY_SUFFIX}")
 set( @PROJECT_NAME@_LIBRARIES ${OpenVDBLibraries} tbb Half boost_system boost_iostreams z)

--- a/cmake/openvdb-extras.cmake.in
+++ b/cmake/openvdb-extras.cmake.in
@@ -1,4 +1,3 @@
 # This overrides the dependency tracker with the OpenVDB library file.
-file(GLOB OpenVDBLibraries @CATKIN_DEVEL_PREFIX@/lib/libopenvdb*)
-set( @PROJECT_NAME@_LIBRARIES ${OpenVDBLibraries} tbb Half)
-
+set(OpenVDBLibraries "${CATKIN_DEVEL_PREFIX}/lib/libopenvdb.so")
+set( @PROJECT_NAME@_LIBRARIES ${OpenVDBLibraries} tbb Half boost_system boost_iostreams z)

--- a/package.xml
+++ b/package.xml
@@ -11,5 +11,5 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
   
-  <build_depend>boost</build_depend>
+  <build_depend>Boost</build_depend>
 </package>


### PR DESCRIPTION
@simonlynen This should fix the circular dependency in openvdb_interface, it was this line that added libopenvdb_interface.so to the list of dependencies:
`file(GLOB OpenVDBLibraries @CATKIN_DEVEL_PREFIX@/lib/libopenvdb*)`
I renamed some of the Variables based on how they are defined in the find scripts, not sure if that was necessary though. 
